### PR TITLE
Fix aggregation of included numeric fields in grouped table reports

### DIFF
--- a/advanced_report_builder/views/datatables/utils.py
+++ b/advanced_report_builder/views/datatables/utils.py
@@ -168,6 +168,12 @@ class TableUtilsMixin(ReportUtilsMixin):
 
             if annotations_type != 0 or append_annotation_query != 0:
                 has_annotations = True
+            # Columns that carry their own pre-built annotation (e.g. a Sum/Count defined on the
+            # report builder column) also make the query aggregate. Count them so the default
+            # (non-aggregate) columns are not injected, which would otherwise be added to the
+            # GROUP BY and break grouping (every row splits out on its own line).
+            if col_type_override is not None and getattr(col_type_override, 'annotations', None):
+                has_annotations = True
 
             if isinstance(django_field, DATE_FIELDS):
                 field_name = self.get_date_field(

--- a/advanced_report_builder/views/report_utils_mixin.py
+++ b/advanced_report_builder/views/report_utils_mixin.py
@@ -215,6 +215,13 @@ class ReportUtilsMixin(ReportBuilderFieldUtils, FilterQueryMixin):
                         function = ExpressionWrapper(function / NullIf(float(divider), 0.0), output_field=FloatField())
                     function = Round(function, decimal_places)
 
+                    # field.field already carries the full ORM path (e.g. 'item_summary__doors'),
+                    # so this annotation is self-contained. Clear model_path so the column's
+                    # annotation setter does not re-prefix it - re-prefixing both double-prefixes
+                    # the alias ("Unable to find column ...") and crashes on wrapped expressions
+                    # such as Round(Sum(...), Value(2)) ("'Value' object has no attribute 'name'").
+                    field.model_path = ''
+
                     if self.use_annotations:
                         field.annotations = {new_field_name: function}
                     else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,6 +65,15 @@ def restore_baseline():
             capture_output=True,
         )
 
+    # The baseline dump is a point-in-time snapshot, so apply any migrations added since
+    # it was captured. Without this a newer column (e.g. tablereport.allow_new_version)
+    # is missing and every report-creating test fails on insert.
+    subprocess.run(
+        [*compose, 'exec', '-T', 'django_report_builder', 'python', 'manage.py', 'migrate', '--noinput'],
+        check=True,
+        capture_output=True,
+    )
+
 
 @pytest.fixture(scope='session', autouse=True)
 def reset_database():

--- a/tests/test_table_reports.py
+++ b/tests/test_table_reports.py
@@ -301,3 +301,63 @@ def test_table_report_currency_prefix_custom(authenticated_page):
     # Currency values should have $ prefix
     first_cell = page.locator('table.dataTable tbody tr td').first
     expect(first_cell).to_contain_text('$', timeout=5000)
+
+
+def _set_table_fields(report_name, fields):
+    """Replace a report's entire table_fields list (JSON) directly in the DB."""
+    import base64
+    import json
+
+    b64 = base64.b64encode(json.dumps(fields).encode()).decode()
+    stdout, stderr = _run_django_shell(f"""
+import base64, json
+from advanced_report_builder.models import TableReport
+report = TableReport.objects.get(name='{report_name}')
+report.table_fields = json.loads(base64.b64decode('{b64}').decode())
+report.save()
+print('OK')
+""")
+    assert 'OK' in stdout, f'Failed to set table_fields: {stderr}'
+
+
+def test_table_report_sum_of_included_field_grouped_by_week(authenticated_page):
+    """Regression test for summing a numeric field reached through an include.
+
+    Person includes Company, so ``company__importance`` is a number column with a
+    non-empty ``model_path``. Summing it (annotations_type=1) and grouping by the
+    week-truncated ``date_entered`` (annotations_value=4) used to:
+      * crash with "'Value' object has no attribute 'name'" while building the
+        ``Round(Sum(...))`` annotation (django-datatables column rewrite), and
+      * once that was worked around, split every row out on its own line because
+        the pre-annotated column was not counted toward ``has_annotations`` and the
+        default ``id`` column got added to the GROUP BY.
+
+    With the fix the report renders one aggregated row per week showing the summed
+    importance (885 across the single seeded week), instead of 193 ungrouped rows.
+    """
+    page = authenticated_page
+    _create_table_report(page, 'Weekly Importance', report_type='Person')
+
+    _set_table_fields(
+        'Weekly Importance',
+        [
+            {'field': 'date_entered', 'title': 'Week', 'data_attr': 'annotations_value-4-date_format-2'},
+            {
+                'field': 'company__importance',
+                'title': 'Total Importance',
+                'data_attr': 'annotations_type-1-show_totals-1',
+            },
+        ],
+    )
+
+    _navigate_to_report(page, 'Weekly Importance')
+
+    # Renders without the crash: the summed column header and a data row are present.
+    expect(page.locator('th', has_text='Total Importance').first).to_be_visible(timeout=10000)
+    rows = page.locator('table.dataTable tbody tr')
+    assert rows.count() > 0, 'Expected the report to render aggregated rows, not crash'
+
+    # Grouped, not one row per person: 193 people collapse to a single weekly total of 885.
+    info = page.locator('.dataTables_info')
+    expect(info).not_to_contain_text('193', timeout=5000)
+    expect(page.locator('table.dataTable tbody tr').first).to_contain_text('885', timeout=5000)


### PR DESCRIPTION
## Problem

Summing a numeric field reached through an **include** (so the column has a non-empty `model_path`, e.g. `company__importance`) in a **grouped** table report was broken in two ways:

1. **Crash.** `get_number_field` builds the `Sum` from the full ORM path and wraps it in `Round(Sum(...))`. Because the column still carried its `model_path`, django-datatables' annotation setter re-prefixed the expression tree and raised:
   ```
   AttributeError: 'Value' object has no attribute 'name'
   ```
   (it choked on the `Round` precision `Value`), and would otherwise double-prefix the alias → `Unable to find column ...`.

2. **Broken grouping.** A column carrying its own pre-built annotation wasn't counted toward `has_annotations`, so the default (non-aggregate) columns were injected and added to the `GROUP BY` — splitting every row onto its own line instead of aggregating per group.

## Fix

- `report_utils_mixin.py` — the dynamically-built annotation is self-contained (its `Sum` already uses the full path via `field.field`), so clear `model_path` before assigning it. Stops the re-prefix crash and the double-prefixed alias.
- `datatables/utils.py` — count columns whose `col_type_override.annotations` is truthy toward `has_annotations`, so pre-annotated columns suppress the default-column injection and group correctly.

## Tests

- New Playwright regression test `test_table_report_sum_of_included_field_grouped_by_week`: a **Person** report summing `company__importance` grouped by week. Verified it **fails without** either fix (hits the exact `'Value' object has no attribute 'name'` crash) and **passes with** them (193 people collapse to a single weekly total of 885). Full `test_table_reports.py` is green (12 passed).
- `conftest.py` — run `migrate` after restoring `baseline.dump`. The snapshot predates `tablereport.allow_new_version`, so without this every report-creating test 500s on insert.

## Notes

There is a companion defensive hardening in **django-datatables** (`_set_annotations` made recursive / literal-safe) for other nested-annotation cases; it's a separate repo and not required for this fix (the `model_path` clear short-circuits the crash for this path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)