### PR TITLE
Fix nested pivot id losing parent include prefix

### DIFF
--- a/advanced_report_builder/filter_query.py
+++ b/advanced_report_builder/filter_query.py
@@ -930,10 +930,10 @@ class FilterQueryMixin:
 
         if '__' in pivot_str:
             pivot_parts = pivot_str.split('__')
-            include_str = pivot_parts[0]
+            first_part = pivot_parts[0]
             new_pivot_str = '__'.join(pivot_parts[1:])
 
-            include = report_builder_class.includes.get(include_str)
+            include = report_builder_class.includes.get(first_part)
             if include is not None:
                 app_label, model, report_builder_fields_str = include['model'].split('.')
                 new_model = apps.get_model(app_label, model)
@@ -941,12 +941,18 @@ class FilterQueryMixin:
                     model=new_model, class_name=report_builder_fields_str
                 )
                 if new_model != previous_base_model:
+                    # Accumulate the full include path so nested (2+ level) pivots keep their
+                    # parent prefix. Previously only the deepest include was kept, producing an
+                    # id like 'project_salesman__formatted_name' instead of the full
+                    # 'project_wide_information__project_salesman__formatted_name', which then
+                    # failed to resolve as a column path.
+                    next_include_str = first_part if include_str == '' else '__'.join((include_str, first_part))
                     result = self._get_pivot_details(
                         base_model=new_model,
                         pivot_str=new_pivot_str,
                         report_builder_class=new_report_builder_class,
                         previous_base_model=base_model,
-                        include_str=include_str,
+                        include_str=next_include_str,
                     )
                     if result:
                         return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-advanced-report-builder"
-version = "1.3.8"
+version = "1.3.9"
 description = "Django app that allows you to build reports from modals"
 readme = "README.md"
 requires-python = ">=3.6"


### PR DESCRIPTION
## Problem

`_get_pivot_details` only kept the **deepest** include segment when resolving a pivot more than one include level deep. A pivot such as:

```
project_wide_information__project_salesman__formatted_name
```

was reduced to `project_salesman__formatted_name`, which then failed to resolve as a column path (`FieldDoesNotExist: <Model> has no field named 'project_salesman'`) when added via `add_columns`. In a consuming app this crashed the entire table/page render — there was no way for the surrounding view to recover.

## Cause

In the recursive `__` branch, the local variable `include_str` was reassigned to `pivot_parts[0]`, clobbering the accumulated prefix passed in from the parent call, and only that single segment was forwarded to the next recursion. Intermediate include levels were therefore dropped from the final id.

## Fix

Accumulate the full include path through the recursion (`next_include_str = first_part if include_str == '' else include_str + '__' + first_part`) so the returned id retains every parent prefix. Single-level pivots are unaffected.

## Verification

Reproduced against a real tenant where a 2-level nested pivot mangled the id and 500'd the projects page. After the fix, `_get_pivot_details('project_wide_information__project_salesman__formatted_name')` returns the full, correctly-prefixed id and the table builds cleanly; single-level pivots (e.g. `project_type__name`) continue to resolve as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)