### PR TITLE
Isolate MultiValueReport cell failures and reject summing pk fields

### DIFF
--- a/advanced_report_builder/views/multi_value.py
+++ b/advanced_report_builder/views/multi_value.py
@@ -908,15 +908,20 @@ class MultiValueView(ValueBaseView):
                 elif multi_value_type == MultiValueReportCell.MultiValueType.EQUATION:
                     multi_value_report_equations.append((cell_name, multi_value_report_cell))
             except ReportError as e:
-                value = e.value
+                value = f'{cell_name}: {e.value}'
+            except Exception as e:  # noqa: BLE001 - contain a bad cell rather than 500-ing the whole grid
+                value = f'{cell_name}: {e}'
 
             if fields:
                 try:
                     value, raw_value = self.render_value(
                         base_model=base_model, fields=fields, multi_value_report_cell=multi_value_report_cell
                     )
-                except (AttributeError, TypeError) as e:
-                    value = e
+                # A cell that fails to render (e.g. a non-aggregatable field wrongly summed) must not
+                # take down the whole report - show the error in the cell, prefixed with its grid
+                # reference (e.g. "B2") so it is clear which cell failed.
+                except Exception as e:  # noqa: BLE001
+                    value = f'{cell_name}: {getattr(e, "value", e)}'
                     raw_value = None
                 if raw_value is not None:
                     with contextlib.suppress(ValueError):

--- a/advanced_report_builder/views/multi_value.py
+++ b/advanced_report_builder/views/multi_value.py
@@ -1,5 +1,6 @@
 import contextlib
 import json
+import logging
 from copy import deepcopy
 
 from django.conf import settings
@@ -8,6 +9,7 @@ from django.forms import CharField, ChoiceField, ModelChoiceField
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
+from django.utils.html import escape
 from django_datatables.columns import ColumnBase, MenuColumn
 from django_datatables.datatables import DatatableTable
 from django_datatables.helpers import DUMMY_ID
@@ -51,6 +53,8 @@ from advanced_report_builder.views.modals_base import QueryBuilderModalBase
 from advanced_report_builder.views.query_modal.mixin import MultiQueryModalMixin
 from advanced_report_builder.views.value_base import ValueBaseView
 from advanced_report_builder.widgets import SmallNumberInputWidget
+
+logger = logging.getLogger(__name__)
 
 
 class MultiValueModal(ModelFormModal):
@@ -795,6 +799,15 @@ class MultiValueView(ValueBaseView):
             *self.duplicate_menu(request=request, report_id=chart_report_id),
         ]
 
+    @staticmethod
+    def _cell_error(cell_name, err):
+        """Contain a per-cell failure: log the full exception server-side and return a short,
+        HTML-escaped message for display. The cell value is later emitted into ``{{ html|safe }}``,
+        so the returned text MUST be escaped to avoid injecting an exception message into the page."""
+        message = getattr(err, 'value', err)
+        logger.warning('MultiValueReport cell %s failed to render: %s', cell_name, message, exc_info=err)
+        return escape(f'{cell_name}: {message}')
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs) if hasattr(super(), 'get_context_data') else {}
 
@@ -908,9 +921,9 @@ class MultiValueView(ValueBaseView):
                 elif multi_value_type == MultiValueReportCell.MultiValueType.EQUATION:
                     multi_value_report_equations.append((cell_name, multi_value_report_cell))
             except ReportError as e:
-                value = f'{cell_name}: {e.value}'
+                value = self._cell_error(cell_name, e)
             except Exception as e:  # noqa: BLE001 - contain a bad cell rather than 500-ing the whole grid
-                value = f'{cell_name}: {e}'
+                value = self._cell_error(cell_name, e)
 
             if fields:
                 try:
@@ -921,7 +934,7 @@ class MultiValueView(ValueBaseView):
                 # take down the whole report - show the error in the cell, prefixed with its grid
                 # reference (e.g. "B2") so it is clear which cell failed.
                 except Exception as e:  # noqa: BLE001
-                    value = f'{cell_name}: {getattr(e, "value", e)}'
+                    value = self._cell_error(cell_name, e)
                     raw_value = None
                 if raw_value is not None:
                     with contextlib.suppress(ValueError):

--- a/advanced_report_builder/views/value_base.py
+++ b/advanced_report_builder/views/value_base.py
@@ -1,4 +1,4 @@
-from django.db.models import Count, ExpressionWrapper, FloatField, Sum
+from django.db.models import AutoField, Count, ExpressionWrapper, FloatField, Sum
 from django.db.models.functions import Coalesce, NullIf
 
 from advanced_report_builder.column_types import NUMBER_FIELDS
@@ -40,7 +40,14 @@ class ValueBaseView(ChartBaseView):
             report_builder_class=report_builder_class,
         )
 
-        if isinstance(django_field, NUMBER_FIELDS) or col_type_override is not None and col_type_override.annotations:
+        has_annotation = col_type_override is not None and col_type_override.annotations
+        # An AutoField (primary key) is technically an IntegerField but is never meaningfully
+        # summable. Without this guard a Python-computed column whose underlying field is the pk
+        # (e.g. one that resolves to 'id') is mistaken for a number field, builds Sum('id'), and
+        # then crashes when its row_result looks for the (now absent) 'id' column. Reject it with a
+        # clean error unless the column supplies a real aggregation annotation.
+        is_summable_number = isinstance(django_field, NUMBER_FIELDS) and not isinstance(django_field, AutoField)
+        if is_summable_number or has_annotation:
             self.get_number_field(
                 annotations_type=aggregations_type,
                 append_annotation_query=False,

--- a/advanced_report_builder/views/value_base.py
+++ b/advanced_report_builder/views/value_base.py
@@ -1,4 +1,4 @@
-from django.db.models import AutoField, Count, ExpressionWrapper, FloatField, Sum
+from django.db.models import Count, ExpressionWrapper, FloatField, Sum
 from django.db.models.functions import Coalesce, NullIf
 
 from advanced_report_builder.column_types import NUMBER_FIELDS
@@ -41,12 +41,14 @@ class ValueBaseView(ChartBaseView):
         )
 
         has_annotation = col_type_override is not None and col_type_override.annotations
-        # An AutoField (primary key) is technically an IntegerField but is never meaningfully
-        # summable. Without this guard a Python-computed column whose underlying field is the pk
-        # (e.g. one that resolves to 'id') is mistaken for a number field, builds Sum('id'), and
-        # then crashes when its row_result looks for the (now absent) 'id' column. Reject it with a
-        # clean error unless the column supplies a real aggregation annotation.
-        is_summable_number = isinstance(django_field, NUMBER_FIELDS) and not isinstance(django_field, AutoField)
+        # A primary key is technically an integer field but is never meaningfully summable. Without
+        # this guard a Python-computed column whose underlying field is the pk (e.g. one that
+        # resolves to 'id') is mistaken for a number field, builds Sum('id'), and then crashes when
+        # its row_result looks for the (now absent) 'id' column. Guard on primary_key (not AutoField)
+        # so an explicit IntegerField(primary_key=True) is caught too. Reject unless the column
+        # supplies a real aggregation annotation.
+        is_primary_key = getattr(django_field, 'primary_key', False)
+        is_summable_number = isinstance(django_field, NUMBER_FIELDS) and not is_primary_key
         if is_summable_number or has_annotation:
             self.get_number_field(
                 annotations_type=aggregations_type,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-advanced-report-builder"
-version = "1.3.9"
+version = "1.3.10"
 description = "Django app that allows you to build reports from modals"
 readme = "README.md"
 requires-python = ">=3.6"


### PR DESCRIPTION
## Problem

A `MultiValueReport` cell that sums a **non-aggregatable, Python-computed column** — one whose underlying field resolves to the model primary key `id` (e.g. a datatable column with `col_setup` setting `self.field = 'id'`) — used to **500 the entire report**.

Because `BigAutoField`/`AutoField` is a subclass of `IntegerField`, it passes `NUMBER_FIELDS`, so `_process_aggregations` treats the column as summable and builds `Sum('id')`. The grouped/aggregated result row then has no `id` column, and the column's `row_result` raises `KeyError('id')` (wrapped as `ReportError` in `charts_base.py`). In `MultiValueView.get_context_data`, the `render_value()` call only caught `(AttributeError, TypeError)`, so the `ReportError` escaped and 500'd the whole page — with a traceback that never named which cell caused it.

## Changes

- **`views/multi_value.py`** — contain a failing cell (both while building the aggregation and in `render_value`) and set its value to a message **prefixed with the cell's grid reference** (e.g. `B2: ...`), so a single bad cell renders an in-grid, labelled error instead of taking down the whole grid.
- **`views/value_base.py`** — an `AutoField` (primary key) is technically an `IntegerField` but is never meaningfully summable. `_process_aggregations` now rejects it with a clean `ReportError('not a number field')` unless the column supplies a real aggregation annotation — fixing the `Sum('id')` crash at source.
- Bump version to `1.3.10`.

## Behaviour after

- Summing a pk-backed / non-aggregatable column → clean `"<cell>: not a number field"` in that cell; the rest of the report renders.
- Any other per-cell rendering error → shown in-cell, prefixed with the cell reference, rather than 500-ing the page.
- Columns with a real `annotations` aggregation are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)